### PR TITLE
Fix button label and tooltip text in PromptInput component

### DIFF
--- a/src/components/PromptInput.jsx
+++ b/src/components/PromptInput.jsx
@@ -184,15 +184,15 @@ const PromptInput = ({
             />
             <DoubleButton
               primaryText={
-                languageMode === "spanishHelp" ? "Explore" : "Explora"
+                languageMode === "spanishHelp" ? "Explain" : "Explica"
               }
               secondaryText={
                 languageMode === "spanishHelp" ? "Translate" : "Traduce"
               }
               primaryToolTip={
                 languageMode === "spanishHelp"
-                  ? "[ctrl/cmd + enter] Explore the topic in depth"
-                  : "[ctrl/cmd + enter] Explora el tema en profundidad"
+                  ? "[ctrl/cmd + enter] Explain the topic in depth"
+                  : "[ctrl/cmd + enter] Explica el tema en profundidad"
               }
               secondaryToolTip={
                 languageMode === "spanishHelp"


### PR DESCRIPTION
## Summary
Updated button labels and tooltip text in the PromptInput component to use more accurate terminology for the primary action.

## Changes
- Changed primary button label from "Explore" to "Explain" (English mode)
- Changed primary button label from "Explora" to "Explica" (Spanish mode)
- Updated corresponding tooltip text from "Explore the topic in depth" to "Explain the topic in depth" (English)
- Updated corresponding tooltip text from "Explora el tema en profundidad" to "Explica el tema en profundidad" (Spanish)

## Details
The terminology change better reflects the actual functionality of the primary button action, which is to explain/explica rather than explore/explora a topic. This improves clarity for users in both English and Spanish language modes.

https://claude.ai/code/session_014pBsRvBzCAaDg586KMyTaW