### PR TITLE
Fix mobile input covered by browser UI chrome

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,6 @@ import { lightTheme, darkTheme, spacing, borderRadii } from "./theme";
 const AppContainer = styled.div`
   display: flex;
   flex-direction: column;
-  height: 100vh;
   height: 100dvh;
   overflow: hidden;
   padding: ${({ theme }) => theme.spacing.large} 0;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ const AppContainer = styled.div`
   display: flex;
   flex-direction: column;
   height: 100vh;
+  height: 100dvh;
   overflow: hidden;
   padding: ${({ theme }) => theme.spacing.large} 0;
 


### PR DESCRIPTION
Use 100dvh (dynamic viewport height) as a progressive enhancement over
100vh so the layout adapts to the actual visible area on mobile Chrome,
preventing the input from being obscured by the address/navigation bar.

https://claude.ai/code/session_01GtYbiUbv88vpwC9CJ6KCG6