### PR TITLE
Use media-aware theme-color meta tags for light/dark status bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#FCFCFD" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#1A1A1A" media="(prefers-color-scheme: dark)">
     <meta name="description" content="Your personal Spanish language learning assistant">
     <title>Entrenador de español</title>
   </head>


### PR DESCRIPTION
Replace the single static theme-color meta tag with two conditional
tags using prefers-color-scheme media queries, so Android's status
bar matches the app background (#FCFCFD light, #1A1A1A dark).

https://claude.ai/code/session_011tCyy2xwvSYjzhmjMMfMkp