### PR TITLE
Send reCAPTCHA login/logout tokens to backend audit endpoint

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import "./App.css";
 import { ThemeProvider } from "styled-components";
 import { lightTheme, darkTheme, spacing, borderRadii } from "./theme";
 import { useAuth } from "./auth/AuthContext";
+import { auditRecaptcha } from "./api/recaptcha";
 
 const AppContainer = styled.div`
   display: flex;
@@ -160,7 +161,8 @@ function App() {
   };
 
   const handleSignOut = async () => {
-    await window.executeRecaptcha?.("LOGOUT");
+    const token = await window.executeRecaptcha?.("LOGOUT");
+    auditRecaptcha(token, "LOGOUT"); // fire-and-forget
     await signOut();
   };
 

--- a/src/api/recaptcha.js
+++ b/src/api/recaptcha.js
@@ -1,0 +1,15 @@
+const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000";
+
+export async function auditRecaptcha(token, action) {
+  try {
+    const response = await fetch(`${API_URL}/audit`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token, action }),
+    });
+    if (!response.ok) return { success: false, score: 0 };
+    return response.json();
+  } catch {
+    return { success: false, score: 0 };
+  }
+}

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { useAuth } from "../auth/AuthContext";
+import { auditRecaptcha } from "../api/recaptcha";
 
 const Wrapper = styled.div`
   display: flex;
@@ -103,7 +104,12 @@ const LoginScreen = ({ languageMode }) => {
     setBusy(true);
     setError(null);
     try {
-      await window.executeRecaptcha?.("LOGIN");
+      const token = await window.executeRecaptcha?.("LOGIN");
+      const audit = await auditRecaptcha(token, "LOGIN");
+      if (!audit.success || audit.score < 0.5) {
+        setError("Security check failed. Please try again.");
+        return;
+      }
       await signInWithGoogle();
     } catch (err) {
       if (err.code !== "auth/popup-closed-by-user") {


### PR DESCRIPTION
## Summary

Fixes the login/logout reCAPTCHA flows. Previously `window.executeRecaptcha("LOGIN")` and `("LOGOUT")` were called, but the returned tokens were thrown away — they were never sent to the backend, so the calls provided no security value.

- **New `src/api/recaptcha.js`** with an `auditRecaptcha(token, action)` helper, following the same fetch-wrapper pattern as `src/api/history.js`.
- **`LoginScreen.jsx`** — captures the token, POSTs it to the backend `/audit` endpoint, and blocks sign-in if `score < 0.5` (same threshold the translation endpoint uses).
- **`App.jsx`** (`handleSignOut`) — captures the token and fires `auditRecaptcha` without awaiting; sign-out proceeds immediately. Blocking logout on a network call would be bad UX, but the token still gets verified + logged server-side.

## Companion PR

Requires the backend `/audit` endpoint added in spanish-coach-backend on the matching branch.

## Test plan

- [ ] Sign in with Google — verify network tab shows `POST /audit` with `action: "LOGIN"` before the Google popup opens
- [ ] Sign out — verify network tab shows `POST /audit` with `action: "LOGOUT"`
- [ ] Translation flow still works (regression check; no changes to `handleSubmit`)
- [ ] With reCAPTCHA blocked (e.g., adblocker), login shows "Security check failed" error and does not call Firebase

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVC2nt4WM6HbnZRKoEWZKq)_